### PR TITLE
feat: add platform-specific pre-ack emoji

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -115,6 +115,15 @@ DEFAULT_CONFIG = {
         "port": 6185,
     },
     "platform": [],
+    "platform_specific": {
+        # NOTE: 当前仅支持 Telegram、飞书、Discord 和 Slack
+        "pre_ack_emoji": {
+            "enable": False,
+            # 可填写多个表情枚举字符串，将随机选取一个响应
+            # 飞书表情枚举参考: https://open.feishu.cn/document/server-docs/im-v1/message-reaction-emoji
+            "emojis": ["SMILE"],
+        },
+    },
     "wake_prefix": ["/"],
     "log_level": "INFO",
     "pip_install_arg": "",
@@ -2182,6 +2191,26 @@ CONFIG_METADATA_3 = {
                     },
                 },
             },
+        },
+    },
+    "platform_specific_group": {
+        "name": "平台特异配置",
+        "metadata": {
+            "pre_ack": {
+                "description": "处理前表情回应",
+                "type": "object",
+                "items": {
+                    "platform_specific.pre_ack_emoji.enable": {
+                        "description": "启用",
+                        "type": "bool",
+                    },
+                    "platform_specific.pre_ack_emoji.emojis": {
+                        "description": "表情枚举列表(参见飞书枚举: https://open.feishu.cn/document/server-docs/im-v1/message-reaction-emoji)",
+                        "type": "list",
+                        "items": {"type": "string"},
+                    },
+                },
+            }
         },
     },
     "plugin_group": {

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -116,13 +116,13 @@ DEFAULT_CONFIG = {
     },
     "platform": [],
     "platform_specific": {
-        # NOTE: 当前仅支持 Telegram、飞书、Discord 和 Slack
-        "pre_ack_emoji": {
-            "enable": False,
-            # 可填写多个表情枚举字符串，将随机选取一个响应
-            # 飞书表情枚举参考: https://open.feishu.cn/document/server-docs/im-v1/message-reaction-emoji
-            "emojis": ["SMILE"],
+        # 平台特异配置：按平台分类，平台下按功能分组
+        "lark": {
+            "pre_ack_emoji": {"enable": False, "emojis": ["Typing"]},
         },
+        "telegram": {
+            "pre_ack_emoji": {"enable": False, "emojis": ["✍️"]},
+        }
     },
     "wake_prefix": ["/"],
     "log_level": "INFO",
@@ -2196,21 +2196,38 @@ CONFIG_METADATA_3 = {
     "platform_specific_group": {
         "name": "平台特异配置",
         "metadata": {
-            "pre_ack": {
-                "description": "处理前表情回应",
+            "lark": {
+                "description": "飞书",
                 "type": "object",
                 "items": {
-                    "platform_specific.pre_ack_emoji.enable": {
-                        "description": "启用",
+                    "platform_specific.lark.pre_ack_emoji.enable": {
+                        "description": "预回应表情",
                         "type": "bool",
                     },
-                    "platform_specific.pre_ack_emoji.emojis": {
-                        "description": "表情枚举列表(参见飞书枚举: https://open.feishu.cn/document/server-docs/im-v1/message-reaction-emoji)",
+                    "platform_specific.lark.pre_ack_emoji.emojis": {
+                        "description": "表情列表（飞书表情枚举名）",
                         "type": "list",
                         "items": {"type": "string"},
+                        "hint": "参考：https://open.feishu.cn/document/server-docs/im-v1/message-reaction/emojis-introduce",
                     },
                 },
-            }
+            },
+            "telegram": {
+                "description": "Telegram",
+                "type": "object",
+                "items": {
+                    "platform_specific.telegram.pre_ack_emoji.enable": {
+                        "description": "预回应表情",
+                        "type": "bool",
+                    },
+                    "platform_specific.telegram.pre_ack_emoji.emojis": {
+                        "description": "表情列表（Unicode，可多选）",
+                        "type": "list",
+                        "items": {"type": "string"},
+                        "hint": "Telegram 仅支持固定反应集合: 👍,👎,❤,🔥,🥰,👏,😁,🤔,🤯,😱,🤬,😢,🎉,🤩,🤮,💩,🙏,👌,🕊,🤡,🥱,🥴,😍,🐳,❤️‍🔥,🌚,🌭,💯,🤣,⚡,🍌,🏆,💔,🤨,😐,🍓,🍾,💋,🖕,😈,😴,😭,🤓,👻,👨‍💻,👀,🎃,🙈,😇,😨,🤝,✍,🤗,🫡,🎅,🎄,☃,💅,🤪,🗿,🆒,💘,🙉,🦄,😘,💊,🙊,😎,👾,🤷‍♂️,🤷,🤷‍♀️,😡",
+                    },
+                },
+            },
         },
     },
     "plugin_group": {

--- a/astrbot/core/pipeline/preprocess_stage/stage.py
+++ b/astrbot/core/pipeline/preprocess_stage/stage.py
@@ -1,11 +1,13 @@
 import traceback
 import asyncio
+import random
 from typing import Union, AsyncGenerator
 from ..stage import Stage, register_stage
 from ..context import PipelineContext
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core import logger
 from astrbot.core.message.components import Plain, Record, Image
+from astrbot.core.message.message_event_result import MessageChain
 
 
 @register_stage
@@ -22,6 +24,16 @@ class PreProcessStage(Stage):
         self, event: AstrMessageEvent
     ) -> Union[None, AsyncGenerator[None, None]]:
         """在处理事件之前的预处理"""
+        pre_ack = self.config.get("platform_specific", {}).get("pre_ack_emoji", {})
+        supported = {"telegram", "lark", "discord", "slack"}
+        if pre_ack.get("enable") and event.get_platform_name() in supported:
+            emojis = pre_ack.get("emojis", [])
+            if emojis:
+                emoji = random.choice(emojis)
+                try:
+                    await event.react(emoji)
+                except Exception as e:
+                    logger.warning(f"预回应表情发送失败: {e}")
         # 路径映射
         if mappings := self.platform_settings.get("path_mapping", []):
             # 支持 Record，Image 消息段的路径映射。

--- a/astrbot/core/platform/astr_message_event.py
+++ b/astrbot/core/platform/astr_message_event.py
@@ -24,7 +24,7 @@ from astrbot.core.provider.entities import ProviderRequest
 from astrbot.core.utils.metrics import Metric
 from .astrbot_message import AstrBotMessage, Group
 from .platform_metadata import PlatformMetadata
-from .message_session import MessageSession, MessageSesion # noqa
+from .message_session import MessageSession, MessageSesion  # noqa
 
 
 class AstrMessageEvent(abc.ABC):
@@ -411,6 +411,10 @@ class AstrMessageEvent(abc.ABC):
             )
         )
         self._has_send_oper = True
+
+    async def react(self, emoji: str):
+        """对消息添加表情回应。默认实现为发送一条包含该表情的消息。"""
+        await self.send(MessageChain([Plain(emoji)]))
 
     async def get_group(self, group_id: str = None, **kwargs) -> Optional[Group]:
         """获取一个群聊的数据, 如果不填写 group_id: 如果是私聊消息，返回 None。如果是群聊消息，返回当前群聊的数据。

--- a/astrbot/core/platform/sources/lark/lark_event.py
+++ b/astrbot/core/platform/sources/lark/lark_event.py
@@ -107,6 +107,23 @@ class LarkMessageEvent(AstrMessageEvent):
 
         await super().send(message)
 
+    async def react(self, emoji: str):
+        request = (
+            CreateMessageReactionRequest.builder()
+            .message_id(self.message_obj.message_id)
+            .request_body(
+                CreateMessageReactionRequestBody.builder()
+                .reaction_type("emoji")
+                .emoji_type(emoji)
+                .build()
+            )
+            .build()
+        )
+        response = await self.bot.im.v1.message_reaction.acreate(request)
+        if not response.success():
+            logger.error(f"发送飞书表情回应失败({response.code}): {response.msg}")
+        await super().send(MessageChain([Plain(emoji)]))
+
     async def send_streaming(self, generator, use_fallback: bool = False):
         buffer = None
         async for chain in generator:

--- a/astrbot/core/platform/sources/telegram/tg_event.py
+++ b/astrbot/core/platform/sources/telegram/tg_event.py
@@ -16,6 +16,7 @@ from telegram.ext import ExtBot
 from astrbot.core.utils.io import download_file
 from astrbot import logger
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path
+from telegram import ReactionTypeEmoji, ReactionTypeCustomEmoji
 
 
 class TelegramPlatformEvent(AstrMessageEvent):
@@ -132,6 +133,39 @@ class TelegramPlatformEvent(AstrMessageEvent):
         else:
             await self.send_with_client(self.client, message, self.get_sender_id())
         await super().send(message)
+
+    async def react(self, emoji: str | None, big: bool = False):
+        """
+        给原消息添加 Telegram 反应：
+        - 普通 emoji：传入 '👍'、'😂' 等
+        - 自定义表情：传入其 custom_emoji_id（纯数字字符串）
+        - 取消本机器人的反应：传入 None 或空字符串
+        """
+        try:
+            # 解析 chat_id（去掉超级群的 "#<thread_id>" 片段）
+            if self.get_message_type() == MessageType.GROUP_MESSAGE:
+                chat_id = (self.message_obj.group_id or "").split("#")[0]
+            else:
+                chat_id = self.get_sender_id()
+
+            message_id = int(self.message_obj.message_id)
+
+            # 组装 reaction 参数（必须是 ReactionType 的列表）
+            if not emoji:  # 清空本 bot 的反应
+                reaction_param = []  # 空列表表示移除本 bot 的反应
+            elif emoji.isdigit():  # 自定义表情：传 custom_emoji_id
+                reaction_param = [ReactionTypeCustomEmoji(emoji)]
+            else:  # 普通 emoji
+                reaction_param = [ReactionTypeEmoji(emoji)]
+
+            await self.client.set_message_reaction(
+                chat_id=chat_id,
+                message_id=message_id,
+                reaction=reaction_param,  # 注意是列表
+                is_big=big,  # 可选：大动画
+            )
+        except Exception as e:
+            logger.error(f"[Telegram] 添加反应失败: {e}")
 
     async def send_streaming(self, generator, use_fallback: bool = False):
         message_thread_id = None


### PR DESCRIPTION
## Summary
- allow multiple configurable pre-ack emojis selected randomly
- add dashboard metadata and Lark reaction support for early acknowledgment

## Testing
- `PYTHONPATH=. pytest` *(fails: Context.__init__ missing required positional arguments)*
- `python -m black astrbot/core/config/default.py astrbot/core/pipeline/preprocess_stage/stage.py astrbot/core/platform/astr_message_event.py astrbot/core/platform/sources/lark/lark_event.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2855484b8832fa1bdf0ac4c78102b